### PR TITLE
scan all isochrones for best solution

### DIFF
--- a/tests/routing_test.py
+++ b/tests/routing_test.py
@@ -101,7 +101,7 @@ class TestRouting_lowWind_noIsland(unittest.TestCase):
 
         path_to_end = res.path + [[*self.track[-1],'']]
         self.assertEqual( res.time, datetime.datetime.fromisoformat('2021-04-02 19:00:00'))
-        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 2844)
+        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 2839)
 
 
 class TestRouting_lowWind_mockIsland_5(unittest.TestCase):

--- a/weatherrouting/routers/linearbestisorouter.py
+++ b/weatherrouting/routers/linearbestisorouter.py
@@ -45,6 +45,8 @@ class LinearBestIsoRouter (Router):
 				isoc = self.calculateIsochrones (time + datetime.timedelta(hours=1), lastlog.isochrones, end)
 			else:
 				isoc = self.calculateIsochrones (time + datetime.timedelta(hours=1), [[(start[0], start[1], time)]], end)
+			nearest_dist = self.getParamValue('minIncrease')
+			nearest_solution = None
 			for p in isoc[-1]:
 				distance_to_end_point = utils.pointDistance (end[0],end[1], p[0], p[1])
 				if distance_to_end_point < self.getParamValue('minIncrease'):
@@ -52,8 +54,11 @@ class LinearBestIsoRouter (Router):
 					maxReachDistance = self.polar.maxReachDistance(p, twd, tws)
 					if utils.pointDistance (end[0],end[1], p[0], p[1]) < abs(maxReachDistance*1.1):
 						if (not self.pointValidity or self.pointValidity(end[0],end[1])) and (not self.lineValidity or self.lineValidity(end[0],end[1], p[0], p[1])):
-							generate_path(p)
-							break
+							if distance_to_end_point < nearest_dist:
+								nearest_dist = distance_to_end_point
+								nearest_solution = p
+			if nearest_solution:
+				generate_path(nearest_solution)
 						
 		else: #out of grib scope
 			minDist = 1000000


### PR DESCRIPTION
Hi Davide, @pcav is out for sailing and he is testing the library. He found a weird behaviour in the positioning of last waypoint before end track point, so I made a little fix to solve it. You can find a brief explanatory tread here: https://github.com/enricofer/wind_forecast_routing/issues/9
Here is the "sunday evening" PR
