### PR TITLE
Abstractions and shortestpathrouter

### DIFF
--- a/tests/linearbestisorouter_test.py
+++ b/tests/linearbestisorouter_test.py
@@ -17,64 +17,18 @@ For detail about GNU see <http://www.gnu.org/licenses/>.
 
 import unittest
 import weatherrouting
-import random
 import datetime
 import os
-import math
 import json
 import datetime
 
 from weatherrouting.routers.linearbestisorouter import LinearBestIsoRouter
-
-class mock_grib:
-    def __init__(self,starttws,starttwd, fuzziness, out_of_scope = None ):
-        self.starttws = starttws
-        self.starttwd = starttwd
-        self.fuzziness = fuzziness
-        self.out_of_scope = out_of_scope
-        self.seedSource = datetime.datetime.fromisoformat('2000-01-01T00:00:00')
-        
-    def tws_var(self,t=None):
-        if t:
-            delta = t - self.seedSource
-            random.seed(delta.total_seconds())
-        return self.starttws + self.starttws*(random.random()*self.fuzziness -self.fuzziness/2)
-
-    def twd_var(self,t=None):
-        if t:
-            delta = t - self.seedSource
-            random.seed(delta.total_seconds())
-        return self.starttwd + self.starttwd*(random.random()*self.fuzziness -self.fuzziness/2)
-
-    def getWindAt(self, t, lat, lon):
-        if not self.out_of_scope or t < self.out_of_scope:
-            return ( math.radians(self.twd_var(t)), self.tws_var(t), )
-        else:
-            return None
-
-class mock_point_validity:
-
-    def __init__(self, track, factor=4):
-        self.mean_point = ((track[0][1]+track[1][1])/2, (track[0][0]+track[1][0])/2)
-        self.mean_island = weatherrouting.utils.pointDistance(*(track[0]+track[1]))/factor
-
-    def point_validity(self, y, x):
-        if weatherrouting.utils.pointDistance(x,y,*(self.mean_point)) < self.mean_island:
-            return False
-        else:
-            return True
-
-    def line_validity(self, y1, x1, y2, x2):
-        if weatherrouting.utils.pointDistance(x1,y2,*(self.mean_point)) < self.mean_island:
-            return False
-        else:
-            return True
+from .mock_grib import mock_grib
+from .mock_point_validity import mock_point_validity
 
 polar_obj = weatherrouting.Polar(os.path.join(os.path.dirname(__file__),'Bavaria38.pol'))
 
-
 class TestRouting_lowWind_noIsland(unittest.TestCase):
-
     def setUp(self):
         grib = mock_grib(2,180,0.1)
         self.track = [(5,38),(5.2,38.2)]
@@ -101,11 +55,10 @@ class TestRouting_lowWind_noIsland(unittest.TestCase):
 
         path_to_end = res.path + [[*self.track[-1],'']]
         self.assertEqual( res.time, datetime.datetime.fromisoformat('2021-04-02 19:00:00'))
-        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 2839)
+        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 2843)
 
 
 class TestRouting_lowWind_mockIsland_5(unittest.TestCase):
-
     def setUp(self):
         grib = mock_grib(2,180,0.1)
         self.track = [(5,38),(5.2,38.2)]
@@ -132,7 +85,6 @@ class TestRouting_lowWind_mockIsland_5(unittest.TestCase):
 
 
 class checkRoute_mediumWind_mockIsland_8(unittest.TestCase):
-
     def setUp(self):
         grib = mock_grib(5,45,0.5) 
         self.track = [(5,38),(4.6,37.6)]
@@ -154,11 +106,10 @@ class checkRoute_mediumWind_mockIsland_8(unittest.TestCase):
             res = self.routing_obj.step()
             i += 1
         
-        self.assertEqual(i, 6)
+        self.assertEqual(i, 7)
         self.assertEqual(not res.path, False)
 
 class checkRoute_highWind_mockIsland_3(unittest.TestCase):
-
     def setUp(self):
         grib = mock_grib(10,270,0.5) 
         self.track = [(5,38),(5.5,38.5)]
@@ -184,7 +135,6 @@ class checkRoute_highWind_mockIsland_3(unittest.TestCase):
         self.assertEqual(not res.path, False)
 
 class checkRoute_out_of_scope(unittest.TestCase):
-
     def setUp(self):
         grib = mock_grib(10,270,0.5,out_of_scope=datetime.datetime.fromisoformat('2021-04-02T15:00:00')) 
         self.track = [(5,38),(5.5,38.5)]

--- a/tests/linearbestisorouter_test.py
+++ b/tests/linearbestisorouter_test.py
@@ -21,6 +21,7 @@ import datetime
 import os
 import json
 import datetime
+import hashlib
 
 from weatherrouting.routers.linearbestisorouter import LinearBestIsoRouter
 from .mock_grib import mock_grib
@@ -55,7 +56,10 @@ class TestRouting_lowWind_noIsland(unittest.TestCase):
 
         path_to_end = res.path + [[*self.track[-1],'']]
         self.assertEqual( res.time, datetime.datetime.fromisoformat('2021-04-02 19:00:00'))
-        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 2843)
+
+        gjs = json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))
+        self.assertEqual(len(gjs), 2843)
+        self.assertEqual(hashlib.sha256(gjs.encode()).hexdigest(), 'd11127f9228c704c47ccfdcac2cc1b8e97ecae5e6212637aa5e1ccc49c6e396a')
 
 
 class TestRouting_lowWind_mockIsland_5(unittest.TestCase):

--- a/tests/main.py.ex
+++ b/tests/main.py.ex
@@ -19,7 +19,8 @@ import unittest
 
 from utils import *
 from polar import *
-from routing import *
+from shortestpathrouter import *
+from linearbestisorouter import *
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mock_grib.py
+++ b/tests/mock_grib.py
@@ -1,0 +1,29 @@
+import random
+import math
+import datetime
+
+class mock_grib:
+    def __init__(self,starttws,starttwd, fuzziness, out_of_scope = None ):
+        self.starttws = starttws
+        self.starttwd = starttwd
+        self.fuzziness = fuzziness
+        self.out_of_scope = out_of_scope
+        self.seedSource = datetime.datetime.fromisoformat('2000-01-01T00:00:00')
+        
+    def tws_var(self,t=None):
+        if t:
+            delta = t - self.seedSource
+            random.seed(delta.total_seconds())
+        return self.starttws + self.starttws*(random.random()*self.fuzziness -self.fuzziness/2)
+
+    def twd_var(self,t=None):
+        if t:
+            delta = t - self.seedSource
+            random.seed(delta.total_seconds())
+        return self.starttwd + self.starttwd*(random.random()*self.fuzziness -self.fuzziness/2)
+
+    def getWindAt(self, t, lat, lon):
+        if not self.out_of_scope or t < self.out_of_scope:
+            return ( math.radians(self.twd_var(t)), self.tws_var(t), )
+        else:
+            return None

--- a/tests/mock_point_validity.py
+++ b/tests/mock_point_validity.py
@@ -1,0 +1,18 @@
+import weatherrouting
+
+class mock_point_validity:
+    def __init__(self, track, factor=4):
+        self.mean_point = ((track[0][1]+track[1][1])/2, (track[0][0]+track[1][0])/2)
+        self.mean_island = weatherrouting.utils.pointDistance(*(track[0]+track[1]))/factor
+
+    def point_validity(self, y, x):
+        if weatherrouting.utils.pointDistance(x,y,*(self.mean_point)) < self.mean_island:
+            return False
+        else:
+            return True
+
+    def line_validity(self, y1, x1, y2, x2):
+        if weatherrouting.utils.pointDistance(x1,y2,*(self.mean_point)) < self.mean_island:
+            return False
+        else:
+            return True

--- a/tests/polar_test.py
+++ b/tests/polar_test.py
@@ -40,5 +40,5 @@ class TestPolar(unittest.TestCase):
 
     def test_max_dist_reaching(self):
         p1 = (5,38)
-        maxd = self.polar_obj.maxReachDistance(p1,90,3)
-        self.assertEqual(maxd, 6.886599679723727, 0.001)
+        maxd = self.polar_obj.maxReachDistance(p1,5)
+        self.assertEqual(maxd, 5.000000000000199, 0.001)

--- a/tests/polar_test.py
+++ b/tests/polar_test.py
@@ -41,4 +41,4 @@ class TestPolar(unittest.TestCase):
     def test_max_dist_reaching(self):
         p1 = (5,38)
         maxd = self.polar_obj.maxReachDistance(p1,90,3)
-        self.assertEqual(maxd, 6.879162747023636, 0.001)
+        self.assertEqual(maxd, 6.886599679723727, 0.001)

--- a/tests/polar_test.py
+++ b/tests/polar_test.py
@@ -37,8 +37,3 @@ class TestPolar(unittest.TestCase):
     def test_reaching(self):
         self.assertEqual(self.polar_obj.getReaching(6.1)[0], 5.3549999999999995, 0.001)
         self.assertEqual(self.polar_obj.getReaching(6.1)[1], 1.3962634015954636, 0.001)
-
-    def test_max_dist_reaching(self):
-        p1 = (5,38)
-        maxd = self.polar_obj.maxReachDistance(p1,5)
-        self.assertEqual(maxd, 5.000000000000199, 0.001)

--- a/tests/shortestpathrouter_test.py
+++ b/tests/shortestpathrouter_test.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017-2021 Davide Gessa
+# Copyright (C) 2021 Enrico Ferreguti
+'''
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+For detail about GNU see <http://www.gnu.org/licenses/>.
+'''
+
+import unittest
+import weatherrouting
+import datetime
+import os
+import json
+import datetime
+
+from weatherrouting.routers.shortestpathrouter import ShortestPathRouter
+from .mock_grib import mock_grib
+from .mock_point_validity import mock_point_validity
+
+
+class TestRouting_noIsland(unittest.TestCase):
+    def setUp(self):
+        grib = mock_grib(2,180,0.1)
+        self.track = [(5,38),(5.2,38.2)]
+        island_route = mock_point_validity(self.track)
+        self.routing_obj = weatherrouting.Routing(
+            ShortestPathRouter,
+            None,
+            self.track,
+            grib,
+            datetime.datetime.fromisoformat('2021-04-02T12:00:00'),
+            pointValidity = island_route.point_validity,
+        )
+        
+    def test_step(self):
+        res = None 
+        i = 0
+        
+        while not self.routing_obj.end:
+            res = self.routing_obj.step()
+            i += 1
+
+        self.assertEqual(i, 3)
+        self.assertEqual(not res.path, False)
+
+        path_to_end = res.path + [[*self.track[-1],'']]
+        self.assertEqual( res.time, datetime.datetime.fromisoformat('2021-04-02 14:00:00'))
+        self.assertEqual(len(json.dumps(weatherrouting.utils.pathAsGeojson(path_to_end))), 1196)
+
+
+class TestRouting_mockIsland_5(unittest.TestCase):
+    def setUp(self):
+        grib = mock_grib(2,180,0.1)
+        self.track = [(5,38),(5.2,38.2)]
+        island_route = mock_point_validity(self.track, factor=5)
+        self.routing_obj = weatherrouting.Routing(
+            ShortestPathRouter,
+            None,
+            self.track,
+            grib,
+            datetime.datetime.fromisoformat('2021-04-02T12:00:00'),
+            pointValidity = island_route.point_validity,
+        )
+        
+    def test_step(self):
+        res = None 
+        i = 0
+        
+        while not self.routing_obj.end:
+            res = self.routing_obj.step()
+            i += 1
+
+        self.assertEqual(i, 3)
+        self.assertEqual(not res.path, False)
+
+
+
+class checkRoute_out_of_scope(unittest.TestCase):
+    def setUp(self):
+        grib = mock_grib(10,270,0.5,out_of_scope=datetime.datetime.fromisoformat('2021-04-02T15:00:00')) 
+        self.track = [(5,38),(5.5,38.5)]
+        island_route = mock_point_validity(self.track, factor=3)
+        self.routing_obj = weatherrouting.Routing(
+            ShortestPathRouter,
+            None,
+            self.track,
+            grib,
+            datetime.datetime.fromisoformat('2021-04-02T12:00:00'),
+            lineValidity = island_route.line_validity,
+        )
+        
+    def test_step(self):
+        res = None 
+        i = 0
+
+        while not self.routing_obj.end:
+            res = self.routing_obj.step()
+            i += 1
+        
+        self.assertEqual(i, 4)
+        self.assertEqual(not res.path, False)
+        

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -21,3 +21,8 @@ import weatherrouting
 class TestUtils(unittest.TestCase):
     def test_pointDistance(self):
         self.assertEqual(round(weatherrouting.utils.pointDistance(0.0, 0.0, 1/60, 0.0)), 1)
+
+    def test_max_dist_reaching(self):
+        p1 = (5,38)
+        maxd = weatherrouting.utils.maxReachDistance(p1,5)
+        self.assertEqual(maxd, 5.000000000000199, 0.001)

--- a/weatherrouting/polar.py
+++ b/weatherrouting/polar.py
@@ -171,8 +171,9 @@ class Polar:
 		return twa
 
 		
-	def maxReachDistance(self,p,twd,tws):
+	def maxReachDistance(self, p, twd, tws, speed = None):
 		dt = (1. / 60. * 60.)
-		speed = self.getRoutageSpeed (tws, math.copysign (twd,1))
-		maxp = utils.routagePointDistance (p[0], p[1], speed*dt*1.85, 1)
+		if speed == None:
+			speed = self.getRoutageSpeed (tws, math.copysign (twd,1)) * utils.NAUTICAL_MILE_IN_KM
+		maxp = utils.routagePointDistance (p[0], p[1], speed * dt, 1)
 		return utils.pointDistance(p[0], p[1], maxp[0], maxp[1])

--- a/weatherrouting/polar.py
+++ b/weatherrouting/polar.py
@@ -171,6 +171,3 @@ class Polar:
 		return twa
 
 		
-	def maxReachDistance(self, p, speed, dt=(1. / 60. * 60.)):
-		maxp = utils.routagePointDistance (p[0], p[1], speed * dt, 1)
-		return utils.pointDistance(p[0], p[1], maxp[0], maxp[1])

--- a/weatherrouting/polar.py
+++ b/weatherrouting/polar.py
@@ -171,9 +171,6 @@ class Polar:
 		return twa
 
 		
-	def maxReachDistance(self, p, twd, tws, speed = None):
-		dt = (1. / 60. * 60.)
-		if speed == None:
-			speed = self.getRoutageSpeed (tws, math.copysign (twd,1)) * utils.NAUTICAL_MILE_IN_KM
+	def maxReachDistance(self, p, speed, dt=(1. / 60. * 60.)):
 		maxp = utils.routagePointDistance (p[0], p[1], speed * dt, 1)
 		return utils.pointDistance(p[0], p[1], maxp[0], maxp[1])

--- a/weatherrouting/routers/linearbestisorouter.py
+++ b/weatherrouting/routers/linearbestisorouter.py
@@ -50,7 +50,7 @@ class LinearBestIsoRouter (Router):
 				distance_to_end_point = utils.pointDistance (end[0],end[1], p[0], p[1])
 				if distance_to_end_point < self.getParamValue('minIncrease'):
 					(twd,tws) = self.grib.getWindAt (time + datetime.timedelta(hours=1), p[0], p[1])
-					maxReachDistance = self.polar.maxReachDistance(p, twd, tws, p[6])
+					maxReachDistance = self.polar.maxReachDistance(p, p[6])
 					if utils.pointDistance (end[0],end[1], p[0], p[1]) < abs(maxReachDistance*1.1):
 						if (not self.pointValidity or self.pointValidity(end[0],end[1])) and (not self.lineValidity or self.lineValidity(end[0],end[1], p[0], p[1])):
 							if distance_to_end_point < nearest_dist:

--- a/weatherrouting/routers/shortestpathrouter.py
+++ b/weatherrouting/routers/shortestpathrouter.py
@@ -18,12 +18,14 @@ For detail about GNU see <http://www.gnu.org/licenses/>.
 
 import datetime
 from .. import utils
-from .router import *
+from .linearbestisorouter import *
 
-class LinearBestIsoRouter (Router):
+class ShortestPathRouter (LinearBestIsoRouter):
 	PARAMS = {
-		'minIncrease': RouterParam('minIncrease', 'Minimum increase (nm)', 'float', 'Set the minimum value for selecting a new valid point', default=10.0, lower=1.0, upper=100.0, step=0.1, digits=1)
+		'minIncrease': RouterParam('minIncrease', 'Minimum increase (nm)', 'float', 'Set the minimum value for selecting a new valid point', default=10.0, lower=1.0, upper=100.0, step=0.1, digits=1),
+		'fixedSpeed': RouterParam('fixedSpeed', 'Fixed speed (kn)', 'float', 'Set the fixed speed', default=5.0, lower=1.0, upper=60.0, step=0.1, digits=1)
 	}
+
 
 	def route (self, lastlog, time, start, end):
 		position = start
@@ -41,16 +43,16 @@ class LinearBestIsoRouter (Router):
 		
 		if self.grib.getWindAt (time + datetime.timedelta(hours=1), end[0],end[1]):
 			if lastlog != None and len (lastlog.isochrones) > 0:
-				isoc = self.calculateIsochrones (time + datetime.timedelta(hours=1), lastlog.isochrones, end)
+				isoc = self.calculateShortestPathIsochrones (self.getParamValue('fixedSpeed'), time + datetime.timedelta(hours=1), lastlog.isochrones, end)
 			else:
-				isoc = self.calculateIsochrones (time + datetime.timedelta(hours=1), [[(start[0], start[1], time)]], end)
+				isoc = self.calculateShortestPathIsochrones (self.getParamValue('fixedSpeed'), time + datetime.timedelta(hours=1), [[(start[0], start[1], time)]], end)
 			nearest_dist = self.getParamValue('minIncrease')
 			nearest_solution = None
 			for p in isoc[-1]:
 				distance_to_end_point = utils.pointDistance (end[0],end[1], p[0], p[1])
 				if distance_to_end_point < self.getParamValue('minIncrease'):
 					(twd,tws) = self.grib.getWindAt (time + datetime.timedelta(hours=1), p[0], p[1])
-					maxReachDistance = self.polar.maxReachDistance(p, twd, tws, p[6])
+					maxReachDistance = (1. / 60. * 60.) * p[6]
 					if utils.pointDistance (end[0],end[1], p[0], p[1]) < abs(maxReachDistance*1.1):
 						if (not self.pointValidity or self.pointValidity(end[0],end[1])) and (not self.lineValidity or self.lineValidity(end[0],end[1], p[0], p[1])):
 							if distance_to_end_point < nearest_dist:

--- a/weatherrouting/utils.py
+++ b/weatherrouting/utils.py
@@ -79,6 +79,11 @@ def routagePointDistance (latA, lonA, distance, hdg, unit='nm'):
 	return (float (of[0]), float (of[1]))
 
 
+def maxReachDistance(p, speed, dt=(1. / 60. * 60.)):
+	maxp = routagePointDistance (p[0], p[1], speed * dt, 1)
+	return pointDistance(p[0], p[1], maxp[0], maxp[1])
+
+
 def reduce360 (alfa):
 	if math.isnan (alfa):
 		return 0.0

--- a/weatherrouting/utils.py
+++ b/weatherrouting/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2017-2021 Davide Gessa
+# Copyright (C) 2021 Enrico Ferreguti
 # Copyright (C) 2012 Riccardo Apolloni
 '''
 This program is free software: you can redistribute it and/or modify
@@ -19,7 +20,8 @@ import LatLon23
 import math
 import json
 
-EARTH_RADIUS=60.0*360/(2*math.pi)#nm
+EARTH_RADIUS = 60.0 * 360 / (2 * math.pi) # nm
+NAUTICAL_MILE_IN_KM = 1.852
 
 def cfbinomiale(n,i):
 	return math.factorial(n)/(math.factorial(n-i)*math.factorial(i))


### PR DESCRIPTION
- abstracting iso creation function for different criteria (not only wind routing)
- shortestpathrouter for fixedSpeed routing (aka motoring)
- nautical mile precision (a precise constant for conversion, avoiding magic numbers in code)
- avoid speed calculation if present in isochrone (there was a redundant calculation for speed)

@enricofer please check this pull, it does not break tests (expect for values depending on nautical mile precision)