### PR TITLE
Benchmark polar speed lookup for PR #28

### DIFF
--- a/scripts/benchmark_polar.py
+++ b/scripts/benchmark_polar.py
@@ -1,0 +1,99 @@
+import math
+import os
+import statistics
+import time
+import random
+
+import weatherrouting
+
+POLAR_PATH = os.path.join(
+            os.path.dirname(__file__), "../tests/data/bavaria38.pol"
+    )
+
+def run_once(polar, samples, iterations, bisect):
+    start = time.perf_counter()
+
+    total = 0.0
+    for _ in range(iterations):
+        for tws, twa in samples:
+            total += polar.get_speed(tws, twa, bisect)
+
+
+    elapsed = time.perf_counter() - start
+    return elapsed, total
+
+def main():
+    polar = weatherrouting.Polar(POLAR_PATH)
+
+    num_tws_samples = 10
+    num_twa_samples = 10
+
+    tws_min = 0.0
+    tws_max = polar.tws[-1] + 10.0
+    twa_min = 0.0
+    twa_max = math.pi
+
+    random.seed(1)
+
+    tws_samples = [
+        random.uniform(tws_min, tws_max)
+        for _ in range(num_tws_samples)
+    ]
+
+    twa_samples = [
+        random.uniform(twa_min, twa_max)
+        for _ in range(num_twa_samples)
+    ]
+
+    samples = [
+        (tws, twa)
+        for tws in tws_samples
+        for twa in twa_samples
+    ]
+
+    iterations = 5_000
+    repeats = 20
+
+    times_old = []
+    checksum_old = None
+
+    times_new = []
+    checksum_new = None
+
+    for _ in range(repeats):
+        elapsed, total = run_once(polar, samples, iterations, False)
+        times_old.append(elapsed)
+        checksum_old = total
+
+        elapsed, total = run_once(polar, samples, iterations, True)
+        times_new.append(elapsed)
+        checksum_new = total
+
+
+    median_old = statistics.median(times_old)
+    median_new = statistics.median(times_new)
+    speedup = median_old / median_new
+    time_reduction = (1 - median_new / median_old) * 100
+    checksum_diff = checksum_new - checksum_old
+
+    print(f"iterations: {iterations}")
+    print(f"samples: {len(samples)}")
+    print(f"repeats: {repeats}")
+
+    print("\n------ OLD ------")
+    print(f"min: {min(times_old):.6f}s")
+    print(f"median: {median_old:.6f}s")
+    print(f"checksum: {checksum_old:.17g}")
+
+    print("\n------ NEW ------")
+    print(f"min: {min(times_new):.6f}s")
+    print(f"median: {median_new:.6f}s")
+    print(f"checksum: {checksum_new:.17g}")
+
+    print("\n------ COMPARISON ------")
+    print(f"median speedup: {speedup:.3f}x")
+    print(f"time reduction: {time_reduction:.2f}%")
+    print(f"checksum difference: {checksum_diff:.17e}")
+
+if __name__ == "__main__":
+    main()

--- a/weatherrouting/polar.py
+++ b/weatherrouting/polar.py
@@ -16,6 +16,7 @@
 # For detail about GNU see <http://www.gnu.org/licenses/>.
 import math
 import re
+from bisect import bisect_left
 from io import TextIOWrapper
 from typing import Dict, Optional, Tuple
 
@@ -80,28 +81,31 @@ class Polar:
 
         return s
 
-    def get_speed(self, tws: float, twa: float) -> float:  # noqa: C901
+    def get_speed(self, tws: float, twa: float, bisect=True) -> float:  # noqa: C901
         """Returns the speed (in knots) given tws (in knots) and twa (in radians)"""
+        if bisect:
+            tws1, tws2 = self._get_idx_bounds(self.tws, tws)
+            twa1, twa2 = self._get_idx_bounds(self.twa, twa)
+        else:
+            tws1 = 0
+            tws2 = 0
 
-        tws1 = 0
-        tws2 = 0
-
-        for k in range(0, len(self.tws)):
-            if tws >= self.tws[k]:
-                tws1 = k
-        for k in range(len(self.tws) - 1, 0, -1):
-            if tws <= self.tws[k]:
-                tws2 = k
-        if tws1 > tws2:  # TWS over table limits
-            tws2 = len(self.tws) - 1
-        twa1 = 0
-        twa2 = 0
-        for k in range(0, len(self.twa)):
-            if twa >= self.twa[k]:
-                twa1 = k
-        for k in range(len(self.twa) - 1, 0, -1):
-            if twa <= self.twa[k]:
-                twa2 = k
+            for k in range(0, len(self.tws)):
+                if tws >= self.tws[k]:
+                    tws1 = k
+            for k in range(len(self.tws) - 1, 0, -1):
+                if tws <= self.tws[k]:
+                    tws2 = k
+            if tws1 > tws2:  # TWS over table limits
+                tws2 = len(self.tws) - 1
+            twa1 = 0
+            twa2 = 0
+            for k in range(0, len(self.twa)):
+                if twa >= self.twa[k]:
+                    twa1 = k
+            for k in range(len(self.twa) - 1, 0, -1):
+                if twa <= self.twa[k]:
+                    twa2 = k
 
         speed1 = self.speed_table[twa1][tws1]
         speed2 = self.speed_table[twa2][tws1]
@@ -196,6 +200,20 @@ class Polar:
                 twa = twadown
         return twa
 
+    def _get_idx_bounds(self, values, value):
+        idx = bisect_left(values, value)
+
+        if idx <= 0:
+            return 0, 0
+
+        if idx >= len(values):
+            last = len(values) - 1
+            return last, last
+
+        if values[idx] == value:
+            return idx, idx
+
+        return idx - 1, idx
     # ---- Start validate function ----
     @staticmethod
     def validate_file(filepath):


### PR DESCRIPTION
This draft PR contains benchmark work for the polar speed lookup change proposed in #28.
The goal is to measure the effect of replacing the linear index scans inside `Polar.get_speed()` with bisection-based lookup, while keeping the interpolation workload and sample set stable.

Benchmark result from a local run:
```
iterations: 5000
samples: 100
repeats: 20

------ OLD ------
min: 2.328427s
median: 2.359820s
checksum: 2163766.985064059

------ NEW ------
min: 0.680327s
median: 0.692512s
checksum: 2163766.985064059

------ COMPARISON ------
median speedup: 3.408x
time reduction: 70.65%
checksum difference: 0.00000000000000000e+00
```

  This branch is intended as supporting evidence for #28 , not as the mergeable implementation branch.