### PR TITLE
Improve `latlon` performance

### DIFF
--- a/scripts/benchmark_latlon.py
+++ b/scripts/benchmark_latlon.py
@@ -31,8 +31,23 @@ def routage_point_distance_run(lat_a, lon_a, d, hdg,):
 
     return t_old, t_new, err
 
+def lossodromic_run(lat_a, lon_a, lat_b, lon_b):
+    start = time.perf_counter()
+    dist_old, hdg_old = utils.lossodromic(lat_a, lon_a, lat_b, lon_b, 
+                                          pyproj=False)
+    t_old = time.perf_counter() - start
+    start = time.perf_counter()
+    dist_new, hdg_new = utils.lossodromic(lat_a, lon_a, lat_b, lon_b,
+                                          pyproj=True)
+    t_new = time.perf_counter() - start
+    err_rel = abs(dist_old-dist_new)/dist_old
+    hdg_rel = abs(hdg_old-hdg_new)/hdg_old
+
+    return t_old, t_new, err_rel, hdg_rel
+
+
 def main():
-    iterations = 100_000
+    iterations = 10_000
 
     # utils.point_distance
     err_rel_pd = 0
@@ -43,6 +58,12 @@ def main():
     err_rp = 0
     t_old_rp = 0
     t_new_rp = 0
+
+    # lossodromic
+    err_loss_dist = 0
+    err_loss_hdg = 0
+    t_old_loss = 0
+    t_new_loss = 0
 
     for _ in range(iterations):
         lat_a = random.uniform(-90, 90)
@@ -64,10 +85,18 @@ def main():
         t_new_rp    += t_new
         err_rp  += err
 
+        # lossodromic
+        t_old, t_new, err_dist, err_hdg = lossodromic_run(lat_a, lon_a,
+                                                          lat_b, lon_b)
+        t_old_loss      += t_old
+        t_new_loss      += t_new
+        err_loss_dist   += err_dist
+        err_loss_hdg    += err_hdg
+
     print(f"Number of iterations: {iterations}")
 
     print(f">> utils.point_distance <<")
-    print(f"Sum relative error = {err_rel_pd:.6f}")
+    print(f"Sum relative error = {err_rel_pd:.3E}")
     print(f"latlon time:      {t_old_pd:.6f}")
     print(f"pyproj time time: {t_new_pd:.6f}")
     print(f"time reduction:   {t_old_pd/t_new_pd:.1f}x")
@@ -78,6 +107,12 @@ def main():
     print(f"pyproj time time: {t_new_rp:.6f}")
     print(f"time reduction:   {t_old_rp/t_new_rp:.1f}x")
 
+    print(f"\n>> utils.lossodromic <<")
+    print(f"Sum relative error (distance) = {err_loss_dist:.3E}")
+    print(f"Sum relative error (angle) =    {err_loss_hdg:.3E}")
+    print(f"latlon time:      {t_old_loss:.6f}")
+    print(f"pyproj time time: {t_new_loss:.6f}")
+    print(f"time reduction:   {t_old_loss/t_new_loss:.1f}x")
 if __name__ == "__main__":
     main()
 

--- a/scripts/benchmark_latlon.py
+++ b/scripts/benchmark_latlon.py
@@ -1,0 +1,83 @@
+import math
+import time
+import random
+random.seed(1)
+from weatherrouting import utils
+
+def point_distance_run(lat_a, lon_a, lat_b, lon_b):
+    start = time.perf_counter()
+    dist_old = utils.point_distance(lat_a, lon_a, lat_b, lon_b,
+                                    "nm", pyproj=False)
+    t_old = time.perf_counter() - start
+    start = time.perf_counter()
+    dist_new = utils.point_distance(lat_a, lon_a, lat_b, lon_b,
+                                    "nm", pyproj=True)
+    t_new = time.perf_counter() - start
+    err_rel = abs(dist_old-dist_new)/dist_old
+
+    return t_old, t_new, err_rel
+
+def routage_point_distance_run(lat_a, lon_a, d, hdg,):
+    start = time.perf_counter()
+    of_old = utils.routage_point_distance(lat_a, lon_a, d, hdg,
+                                              "nm", pyproj=False)
+    t_old = time.perf_counter() - start
+    start = time.perf_counter()
+    of_new = utils.routage_point_distance(lat_a, lon_a, d, hdg,
+                                              "nm", pyproj=True)
+    t_new = time.perf_counter() - start
+    err = utils.point_distance(of_old[0], of_old[1], of_new[0], of_new[1], 
+                                   "nm", pyproj=False)
+
+    return t_old, t_new, err
+
+def main():
+    iterations = 100_000
+
+    # utils.point_distance
+    err_rel_pd = 0
+    t_old_pd = 0
+    t_new_pd = 0
+
+    # routage_point_distance
+    err_rp = 0
+    t_old_rp = 0
+    t_new_rp = 0
+
+    for _ in range(iterations):
+        lat_a = random.uniform(-90, 90)
+        lon_a = random.uniform(-180, 180)
+        lat_b = random.uniform(-90, 90)
+        lon_b = random.uniform(-180, 180)
+        d = random.uniform(0, 100)
+        hdg = random.uniform(0, 2*math.pi)
+
+        # utils.point_distance
+        t_old, t_new, err_rel = point_distance_run(lat_a, lon_a, lat_b, lon_b)
+        t_old_pd    += t_old
+        t_new_pd    += t_new
+        err_rel_pd  += err_rel
+
+        # routage_point_distance
+        t_old, t_new, err = routage_point_distance_run(lat_a, lon_a, d, hdg)
+        t_old_rp    += t_old
+        t_new_rp    += t_new
+        err_rp  += err
+
+    print(f"Number of iterations: {iterations}")
+
+    print(f">> utils.point_distance <<")
+    print(f"Sum relative error = {err_rel_pd:.6f}")
+    print(f"latlon time:      {t_old_pd:.6f}")
+    print(f"pyproj time time: {t_new_pd:.6f}")
+    print(f"time reduction:   {t_old_pd/t_new_pd:.1f}x")
+
+    print(f"\n>> utils.routage_point_distance <<")
+    print(f"Sum errors =      {err_rp:.3E}")
+    print(f"latlon time:      {t_old_rp:.6f}")
+    print(f"pyproj time time: {t_new_rp:.6f}")
+    print(f"time reduction:   {t_old_rp/t_new_rp:.1f}x")
+
+if __name__ == "__main__":
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
     setup_requires="setuptools",
     author_email="gessadavide@gmail.com",
     packages=["weatherrouting", "weatherrouting.routers"],
-    install_requires=["latlon3"],  # ['geographiclib'],
+    install_requires=["latlon3", 'pyproj'],
     test_suite="tests",
 )

--- a/weatherrouting/utils.py
+++ b/weatherrouting/utils.py
@@ -18,9 +18,10 @@ import math
 from typing import Tuple
 
 import latlon
+import pyproj
 
-# from geographiclib.geodesic import Geodesic
-# geod = Geodesic.WGS84
+_GEOD_WGS84 = pyproj.Geod(ellps="WGS84")
+_GEOD_SPHERE = pyproj.Geod(ellps="sphere")
 
 EARTH_RADIUS = 60.0 * 360 / (2 * math.pi)  # nm
 NAUTICAL_MILE_IN_KM = 1.852
@@ -66,15 +67,20 @@ def ortodromic(
 
 
 def lossodromic(
-    lat_a: float, lon_a: float, lat_b: float, lon_b: float
+    lat_a: float, lon_a: float, lat_b: float, lon_b: float, pyproj = True
 ) -> Tuple[float, float]:
     """Returns the lossodromic distance in km between A and B"""
     # g = geod.Inverse(lat_a, lon_a, lat_b, lon_b)
     # return (g['s12'] * 1e-3, math.radians (g['azi1']))
+    if pyproj:
+        heading, _, _ = _GEOD_WGS84.inv(lon_a, lat_a, lon_b, lat_b)
+        _, _, sphere_meters = _GEOD_SPHERE.inv(lon_a, lat_a, lon_b, lat_b)
+        return (sphere_meters / 1000.0, math.radians(heading))
 
-    p1 = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
-    p2 = latlon.LatLon(latlon.Latitude(lat_b), latlon.Longitude(lon_b))
-    return (p1.distance(p2, ellipse="sphere"), math.radians(p1.heading_initial(p2)))
+    else:
+        p1 = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
+        p2 = latlon.LatLon(latlon.Latitude(lat_b), latlon.Longitude(lon_b))
+        return (p1.distance(p2, ellipse="sphere"), math.radians(p1.heading_initial(p2)))
 
 
 def km2nm(d: float) -> float:
@@ -86,12 +92,16 @@ def nm2km(d: float) -> float:
 
 
 def point_distance(
-    lat_a: float, lon_a: float, lat_b: float, lon_b: float, unit: str = "nm"
-) -> float:
+    lat_a: float, lon_a: float, lat_b: float, lon_b: float,
+    unit: str = "nm", pyproj = True) -> float:
     """Returns the distance between two geo points"""
-    p1 = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
-    p2 = latlon.LatLon(latlon.Latitude(lat_b), latlon.Longitude(lon_b))
-    d = p1.distance(p2)
+    if pyproj:
+        _,_,d_m = _GEOD_WGS84.inv(lon_a, lat_a, lon_b, lat_b)
+        d = d_m/1000.0
+    else:
+        p1 = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
+        p2 = latlon.LatLon(latlon.Latitude(lat_b), latlon.Longitude(lon_b))
+        d = p1.distance(p2)
 
     # d = ortodromic(lat_a, lon_a, lat_b, lon_b)[0]
 
@@ -102,19 +112,24 @@ def point_distance(
 
 
 def routage_point_distance(
-    lat_a: float, lon_a: float, distance: float, hdg: float, unit: str = "nm"
-) -> Tuple[float, float]:
+    lat_a: float, lon_a: float, distance: float, hdg: float,
+    unit: str = "nm", pyproj = True) -> Tuple[float, float]:
     """Returns the point from (lat_a, lon_a) to the given (distance, hdg)"""
     if unit == "nm":
         d = nm2km(distance)
     elif unit == "km":
         d = distance
-
+    of = [0.0, 0.0]
     # g = geod.Direct(lat_a, lon_a, math.degrees(hdg), d * 1e3)
     # return (g['lat2'], g['lon2'])
+    if pyproj:
+        hdg_deg = math.degrees(hdg)
+        d_m = d*1000.0
+        of[1], of[0], _ = _GEOD_WGS84.fwd(lon_a, lat_a, hdg_deg, d_m)
+    else:
+        p = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
+        of = p.offset(math.degrees(hdg), d).to_string("D")
 
-    p = latlon.LatLon(latlon.Latitude(lat_a), latlon.Longitude(lon_a))
-    of = p.offset(math.degrees(hdg), d).to_string("D")
     return (float(of[0]), float(of[1]))
 
 


### PR DESCRIPTION
This draft replaces expensive `latlon3` wrapper calls in geographic helpers with direct reusable `pyproj.Geod` calls.
The goal is to keep the same WGS84/spherical geodesic behavior while avoiding repeated object construction, repeated `Geod` construction, string formatting, and string parsing in routing hot paths.

Added `scripts/benchmark_latlon.py` to compare the old `latlon` path against the new direct `pyproj` path for:
- `point_distance`
- `routage_point_distance`
- `lossodromic`

```
Number of iterations: 10000
>> utils.point_distance <<
Sum relative error = 0.000E+00
latlon time:      1.148272
pyproj time time: 0.095083
time reduction:   12.1x

>> utils.routage_point_distance <<
Sum errors =      1.063E-12
latlon time:      1.446403
pyproj time time: 0.118104
time reduction:   12.2x

>> utils.lossodromic <<
Sum relative error (distance) = 0.000E+00
Sum relative error (angle) =    1.106E-15
latlon time:      1.382446
pyproj time time: 0.123218
time reduction:   11.2x
```
 
